### PR TITLE
Add CONFigure:FANx:HYSteresis command

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -14,6 +14,8 @@ Fanpico supports following commands:
 * [CONFigure:DELete](#configuredelete)
 * [CONFigure:FANx:NAME](#configurefanxname)
 * [CONFigure:FANx:NAME?](#configurefanxname-1)
+* [CONFigure:FANx:HYSteresis](#CONFigure:FANx:HYSteresis)
+* [CONFigure:FANx:HYSteresis?](#CONFigure:FANx:HYSteresis-1)
 * [CONFigure:FANx:MINpwm](#configurefanxminpwm)
 * [CONFigure:FANx:MINpwm?](#configurefanxminpwm-1)
 * [CONFigure:FANx:MAXpwm](#configurefanxmaxpwm)
@@ -322,6 +324,23 @@ For example:
 ```
 CONF:FAN1:NAME?
 CPU Fan 1
+```
+
+#### CONFigure:FANx:HYSteresis
+Set the hysteresis threshold for a given fan (output) port.
+
+For example:
+```
+CONF:FAN1:HYSteresis 2.0
+```
+
+#### CONFigure:FANx:HYSteresis?
+Query the hysteresis threshold for a given fan (output) port.
+
+For example:
+```
+CONF:FAN8:HYSteresis?
+CONF:FAN8:HYS=1.000000
 ```
 
 #### CONFigure:FANx:MINpwm

--- a/src/command.c
+++ b/src/command.c
@@ -837,6 +837,31 @@ int cmd_fan_source(const char *cmd, const char *args, int query, char *prev_cmd)
 	return ret;
 }
 
+int cmd_fan_info_hys(const char *cmd, const char *args, int query, char *prev_cmd)
+{
+	int fan;
+	float val;
+
+	fan = atoi(&prev_cmd[3]) - 1;
+	if (fan >= 0 && fan < FAN_COUNT) {
+		if (query) {
+			printf("CONF:FAN%d:HYS=%f\n", fan+1, conf->fans[fan].info_hyst);
+		} else if (str_to_float(args, &val)) {
+			if (val >= 0.0) {
+				log_msg(LOG_NOTICE, "fan%d: change Hysteresis %f --> %f",
+					fan + 1, conf->fans[fan].info_hyst, val);
+				conf->fans[fan].info_hyst = val;
+			} else {
+				log_msg(LOG_WARNING, "fan%d: invalid new value for Hysteresis: %f",
+					fan + 1, val);
+				return 2;
+			}
+		}
+		return 0;
+	}
+	return 1;
+}
+
 int cmd_fan_rpm(const char *cmd, const char *args, int query, char *prev_cmd)
 {
 	int fan;
@@ -2692,6 +2717,7 @@ const struct cmd_t fan_c_commands[] = {
 	{ "RPMFactor", 4, NULL,              cmd_fan_rpm_factor },
 	{ "RPMMOde",   5, NULL,              cmd_fan_rpm_mode },
 	{ "SOUrce",    3, NULL,              cmd_fan_source },
+	{ "HYSteresis",3, NULL,              cmd_fan_info_hys },
 	{ 0, 0, 0, 0 }
 };
 

--- a/src/config.c
+++ b/src/config.c
@@ -489,6 +489,7 @@ void clear_config(struct fanpico_config *cfg)
 		f->rpm_factor = 2;
 		f->filter = FILTER_NONE;
 		f->filter_ctx = NULL;
+		f->info_hyst = FAN_INFO_HYSTERESIS;
 	}
 
 	for (i = 0; i < MBFAN_MAX_COUNT; i++) {
@@ -744,6 +745,7 @@ cJSON *config_to_json(const struct fanpico_config *cfg)
 		cJSON_AddItemToObject(o, "rpm_factor", cJSON_CreateNumber(f->rpm_factor));
 		cJSON_AddItemToObject(o, "lra_low", cJSON_CreateNumber(f->lra_low));
 		cJSON_AddItemToObject(o, "lra_high", cJSON_CreateNumber(f->lra_high));
+		cJSON_AddItemToObject(o, "hysteresis", cJSON_CreateNumber(f->info_hyst));
 		cJSON_AddItemToArray(fans, o);
 	}
 	cJSON_AddItemToObject(config, "fans", fans);
@@ -1092,6 +1094,8 @@ int json_to_config(cJSON *config, struct fanpico_config *cfg)
 				f->lra_high = cJSON_GetNumberValue(r);
 			if ((r = cJSON_GetObjectItem(item, "filter")))
 				json2filter(r, &f->filter, &f->filter_ctx);
+			if ((r = cJSON_GetObjectItem(item, "hysteresis")))
+				f->info_hyst = cJSON_GetNumberValue(r);
 		}
 	}
 

--- a/src/fanpico.h
+++ b/src/fanpico.h
@@ -48,6 +48,7 @@
 #define SENSOR_SERIES_RESISTANCE 10000.0
 
 #define ADC_REF_VOLTAGE 3.0
+#define FAN_INFO_HYSTERESIS 1.0
 #define ADC_MAX_VALUE   (1 << 12)
 #define ADC_AVG_WINDOW  10
 
@@ -138,6 +139,7 @@ struct temp_map {
 
 struct fan_output {
 	char name[MAX_NAME_LEN];
+	float info_hyst;
 
 	/* output PWM signal settings */
 	uint8_t min_pwm;

--- a/src/tacho.c
+++ b/src/tacho.c
@@ -244,8 +244,9 @@ void read_tacho_inputs()
 void update_tacho_input_freq(struct fanpico_state *st)
 {
 	for (int i = 0; i < FAN_COUNT; i++) {
+		float hyst = cfg->fans[i].info_hyst;
 		st->fan_freq[i] = roundf(fan_tacho_freq[i]*100)/100.0;
-		if (check_for_change(st->fan_freq_prev[i], st->fan_freq[i], 1.0)) {
+		if (check_for_change(st->fan_freq_prev[i], st->fan_freq[i], hyst)) {
 			log_msg(LOG_INFO, "fan%d: Input Tacho change %.2fHz --> %.2fHz",
 				i+1,
 				st->fan_freq_prev[i],


### PR DESCRIPTION
Allows user to change the hysteresis of a given fan to limit the amount of INFO lines sent to LOG and/or SYSLOG.